### PR TITLE
refactor:uoloader组件增加单张只读属性

### DIFF
--- a/packages/uploader/index.wxml
+++ b/packages/uploader/index.wxml
@@ -38,7 +38,7 @@
        <text wx:if="{{ item.message }}" class="van-uploader__upload-text">{{ item.message }}</text>
       </view>
       <view
-        wx:if="{{ deletable }}"
+        wx:if="{{ deletable && !item.onlyRead }}"
         data-index="{{ index }}"
         class="van-uploader__preview-delete"
         catch:tap="deleteItem"


### PR DESCRIPTION
uploader组件，deletable属性只能控制全局是否可以删除，不能控制单张图片是否可删除；因此当fileList内为对象时，增加onlyRead标识，当onlyRead为true时，单张不显示删除icon。


